### PR TITLE
Hotfix pre Kodi 18 Leia

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="plugin.video.rtvs.sk" name="rtvs.sk" provider-name="Maros Ondrasek" version="1.0.8">
+<addon id="plugin.video.rtvs.sk" name="rtvs.sk" provider-name="Maros Ondrasek" version="1.8.0">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.module.stream.resolver" version="1.6.13" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+[B]1.8.0:[/B]
+- Kodi 18 Leia update
+- streams from archive was stuttering due ffmpeg bug, solved with InputStream Adaptive
+[B]1.0.8:[/B]
+- ???
 [B]1.0.7:[/B]
 - added all live streams
 - default quality option is set back to always ask

--- a/default.py
+++ b/default.py
@@ -55,6 +55,9 @@ class RtvsXBMCContentProvider(xbmcprovider.XBMCMultiResolverContentProvider):
                     stream['url'] += '|%s=%s' % (header, stream['headers'][header])
             print 'Sending %s to player' % stream['url']
             li = xbmcgui.ListItem(path=stream['url'], iconImage='DefaulVideo.png')
+            if stream['quality'] == 'adaptive':
+                li.setProperty('inputstreamaddon','inputstream.adaptive')
+                li.setProperty('inputstream.adaptive.manifest_type','hls')
             xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, li)
             xbmcutil.load_subtitles(stream['subs'])
 
@@ -62,6 +65,9 @@ class RtvsXBMCContentProvider(xbmcprovider.XBMCMultiResolverContentProvider):
         def select_cb(resolved):
             stream_parts = []
             stream_parts_dict = {}
+
+            if len(resolved) == 1 and resolved[0]['quality'] == 'adaptive':
+                return resolved[0]
 
             for stream in resolved:
                 if stream['surl'] not in stream_parts_dict:

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -30,5 +30,6 @@
 
 	<string id="31010">Kodi 18 Leia</string>
 	<string id="31011">Používáte Leiu, která má problém se skákáním videa z archivu.</string>
-	<string id="31012">Prosím, nainstalujte si InputStream Adaptive plugin z oficiálního repozitáře a nastavte si ho.</string>
+	<string id="31012">Prosím, nainstalujte / aktivujte si InputStream Adaptive plugin z oficiálního repozitáře a nastavte si ho.</string>
+	<string id="31013">Po instalaci / aktivaci je nutný restart Kodi.</string>
 </strings>

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -27,4 +27,8 @@
 	<string id="30061">Nejsledovanější</string>
 	<string id="30070">Podobná videa</string>
 	<string id="31000">Data o použití jsou zaslána pouze v okamžiku, kdy spustíte přehrávání nebo stahování videa doplňkem.</string>
+
+	<string id="31010">Kodi 18 Leia</string>
+	<string id="31011">Používáte Leiu, která má problém se skákáním videa z archivu.</string>
+	<string id="31012">Prosím, nainstalujte si InputStream Adaptive plugin z oficiálního repozitáře a nastavte si ho.</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -28,4 +28,8 @@
 	<string id="30061">Most watched</string>
 	<string id="30070">Related videos</string>
 	<string id="31000">Usage of plugin is tracked whenever you play or download video.</string>
+
+	<string id="31010">Kodi 18 Leia</string>
+	<string id="31011">You are using Leia, which have problems with video stuttering from archive.</string>
+	<string id="31012">Please install InputStream Adaptive plugin from official repo and configure it.</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -31,5 +31,6 @@
 
 	<string id="31010">Kodi 18 Leia</string>
 	<string id="31011">You are using Leia, which have problems with video stuttering from archive.</string>
-	<string id="31012">Please install InputStream Adaptive plugin from official repo and configure it.</string>
+	<string id="31012">Please install / activate InputStream Adaptive plugin from official repo and configure it.</string>
+	<string id="31013">Kodi restart is required after installation / activation.</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -30,5 +30,6 @@
 
 	<string id="31010">Kodi 18 Leia</string>
 	<string id="31011">Používate Leiu, ktorá má problém so skákaním videa z archívu.</string>
-	<string id="31012">Prosím, nainštalujte si InputStream Adaptive plugin z oficiálneho repozitára a nastavte si ho.</string>
+	<string id="31012">Prosím, nainštalujte / aktivujte si InputStream Adaptive plugin z oficiálneho repozitára a nastavte si ho.</string>
+	<string id="31013">Po inštalácii / aktivácii je potrebný reštart Kodi.</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -27,4 +27,8 @@
 	<string id="30061">Najsledovanejšie</string>
 	<string id="30070">Podobné videá</string>
 	<string id="31000">Dáta o použití sú zasláné len v okamžiku, keď spustíte prehrávánie alebo sťahovanie videa doplnkom.</string>
+
+	<string id="31010">Kodi 18 Leia</string>
+	<string id="31011">Používate Leiu, ktorá má problém so skákaním videa z archívu.</string>
+	<string id="31012">Prosím, nainštalujte si InputStream Adaptive plugin z oficiálneho repozitára a nastavte si ho.</string>
 </strings>

--- a/resources/lib/rtvs.py
+++ b/resources/lib/rtvs.py
@@ -104,7 +104,7 @@ def is_kodi_leia():
         else:
             scriptid = 'plugin.video.rtvs.sk'
             addon = xbmcaddon.Addon(id=scriptid)
-            xbmcgui.Dialog().ok(addon.getLocalizedString(31010), addon.getLocalizedString(31011), addon.getLocalizedString(31012))
+            xbmcgui.Dialog().ok(addon.getLocalizedString(31010), addon.getLocalizedString(31011), addon.getLocalizedString(31012), addon.getLocalizedString(31013))
     return False
 
 class RtvsContentProvider(ContentProvider):

--- a/resources/lib/rtvs.py
+++ b/resources/lib/rtvs.py
@@ -36,7 +36,7 @@ import util
 from provider import ContentProvider
 
 import json
-import xbmc
+import xbmc, xbmcaddon, xbmcgui
 
 START_TOP = '<h2 class="nadpis">Najsledovanejšie</h2>'
 END_TOP = '<h2 class="nadpis">Najnovšie</h2>'
@@ -97,7 +97,9 @@ def is_kodi_leia():
         if 'error' not in data.keys():
             return True
         else:
-            xbmcgui.Dialog().ok('TODO', 'mal by si si installnut inputstream.adaptive')
+            scriptid = 'plugin.video.rtvs.sk'
+            addon = xbmcaddon.Addon(id=scriptid)
+            xbmcgui.Dialog().ok(addon.getLocalizedString(31010), addon.getLocalizedString(31011), addon.getLocalizedString(31012))
     return False
 
 class RtvsContentProvider(ContentProvider):

--- a/resources/lib/rtvs.py
+++ b/resources/lib/rtvs.py
@@ -94,7 +94,12 @@ def is_kodi_leia():
         payload = {'jsonrpc': '2.0','id': 1,'method': 'Addons.GetAddonDetails','params': {'addonid': 'inputstream.adaptive','properties': ['enabled']}}
         response = xbmc.executeJSONRPC(json.dumps(payload))
         data = json.loads(response)
-        if 'error' not in data.keys():
+        print(data)
+        if ('error' not in data.keys() and 
+                'result' in data.keys() and 
+                'addon' in data['result'].keys() and 
+                'enabled' in data['result']['addon'].keys() and 
+                data['result']['addon']['enabled']):
             return True
         else:
             scriptid = 'plugin.video.rtvs.sk'


### PR DESCRIPTION
Kodi 18 ma novu verziu ffmpeg, ktora blbne so streamom rtvs, konkretne v logu hadze nasledovne:

ERROR: ffmpeg[3264]: [h264] Invalid NAL unit 8, skipping.

Sposobuje to "skakanie" streamu.

Obist sa to da vyuzitim InputStream Adaptive.