### PR TITLE
strip System.BuildVersion to true float using re

### DIFF
--- a/resources/lib/rtvs.py
+++ b/resources/lib/rtvs.py
@@ -88,7 +88,7 @@ def get_streams_from_manifest_url(url):
     return result
 
 def is_kodi_leia():
-    version = xbmc.getInfoLabel('System.BuildVersion').split(' ')[0]
+    version = re.split("[, \-!?:]+", xbmc.getInfoLabel('System.BuildVersion'))[0]
     if (float(version) >= 18):
         #chceck if is inputstream.adaptive present
         payload = {'jsonrpc': '2.0','id': 1,'method': 'Addons.GetAddonDetails','params': {'addonid': 'inputstream.adaptive','properties': ['enabled']}}


### PR DESCRIPTION
version = xbmc.getInfoLabel('System.BuildVersion').split(' ')[0] didn't work when version was 18.2-RC2. With proposed change it works with anything devs are coming up with.

Change solves issue #9 